### PR TITLE
remove nil check now that Base.routes always returns a hash

### DIFF
--- a/lib/angelo/server.rb
+++ b/lib/angelo/server.rb
@@ -56,7 +56,7 @@ module Angelo
     end
 
     def route! meth, connection, request
-      if @base.routes[meth] and rs = @base.routes[meth][request.path]
+      if rs = @base.routes[meth][request.path]
         responder = rs.dup
         responder.reset!
         responder.base = @base.new responder


### PR DESCRIPTION
i think this is the only place that there is a nil check in the routes hash
